### PR TITLE
Fix punctuation mistake in twitter:site meta tag and add @

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -53,7 +53,7 @@
 
     <meta name="twitter:card" content="summary" />
     <% if(theme.twitter_handle) { %>
-        <meta name="twitter:site" content="<%= theme.twitter_handle %>" />
+        <meta name="twitter:site" content="@<%= theme.twitter_handle %>" />
     <% } %>
 
     <!-- Title -->

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -53,7 +53,7 @@
 
     <meta name="twitter:card" content="summary" />
     <% if(theme.twitter_handle) { %>
-        <meta name="twitter:site" content="<%= theme.twitter_handle %>>" />
+        <meta name="twitter:site" content="<%= theme.twitter_handle %>" />
     <% } %>
 
     <!-- Title -->


### PR DESCRIPTION
The twitter:site meta tag has an extra `>` which causes the Twitter Card mechanism to fail to parse it properly