### PR TITLE
Add Twitter image and large summary card support

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -51,9 +51,16 @@
         <meta property="og:image" content="<%= config.url %><%= config.cover %>"/>
     <% } %>
 
-    <meta name="twitter:card" content="summary" />
+    <% if(page.twitter_large_card) { %>
+        <meta name="twitter:card" content="summary_large_image" />
+    <% } else { %>
+        <meta name="twitter:card" content="summary" />
+    <% } %>
     <% if(theme.twitter_handle) { %>
         <meta name="twitter:site" content="<%= theme.twitter_handle %>>" />
+    <% } %>
+    <% if(page.twitter_image) { %>
+        <meta name="twitter:image" content="<%= page.twitter_image %>" />
     <% } %>
 
     <!-- Title -->


### PR DESCRIPTION
This adds support for recognizing a new page variable, twitter_image,
which should contain the FULL URL of the image for the webpage, and can
be defined in the page/post Front Matter.

```
...
twitter_image: https://myblogsite.com/img/myimage.jpg
---
```

Also, this supports a new boolean page variable, twitter_large_card, which
can also be set in the page/post Front Matter (twitter_large_card: true)
which will cause Twitter & other embedding applications to present the
preview card with a large image above the summary, rather than a small
image to the left. If this is omitted, then it reverts to the standard summary card.

```
...
twitter_large_card: true
---
```